### PR TITLE
Fix: Add missing shadcn/ui color variables to resolve border-border class error

### DIFF
--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -6,9 +6,51 @@ export default {
     "./src/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
+    container: {
+      center: true,
+      padding: "2rem",
+      screens: {
+        "2xl": "1400px",
+      },
+    },
     extend: {
       colors: {
-        // Divine color palette
+        // Standard shadcn/ui colors (required for border-border, etc.)
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))",
+        },
+        destructive: {
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))",
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))",
+        },
+        popover: {
+          DEFAULT: "hsl(var(--popover))",
+          foreground: "hsl(var(--popover-foreground))",
+        },
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))",
+        },
+        
+        // Divine color palette (preserved)
         divine: {
           50: '#fdf8f6',
           100: '#f2e8e5',
@@ -42,6 +84,11 @@ export default {
           light: '#F8F8FF',      // Light marble
         }
       },
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)",
+      },
       fontFamily: {
         divine: ['Cinzel', 'serif'],
         olympian: ['Philosopher', 'sans-serif'],
@@ -54,6 +101,8 @@ export default {
         'gold-shimmer': 'linear-gradient(45deg, #FFD700 0%, #FFF8DC 50%, #FFD700 100%)',
       },
       animation: {
+        "accordion-down": "accordion-down 0.2s ease-out",
+        "accordion-up": "accordion-up 0.2s ease-out",
         'divine-glow': 'divineGlow 2s ease-in-out infinite',
         'thunder-strike': 'thunderStrike 0.5s ease-out',
         'float': 'float 3s ease-in-out infinite',
@@ -61,6 +110,14 @@ export default {
         'pulse-slow': 'pulse 3s cubic-bezier(0.4, 0, 0.6, 1) infinite',
       },
       keyframes: {
+        "accordion-down": {
+          from: { height: "0" },
+          to: { height: "var(--radix-accordion-content-height)" },
+        },
+        "accordion-up": {
+          from: { height: "var(--radix-accordion-content-height)" },
+          to: { height: "0" },
+        },
         divineGlow: {
           '0%, 100%': {
             boxShadow: '0 0 20px rgba(255, 215, 0, 0.5), 0 0 40px rgba(255, 215, 0, 0.3)',


### PR DESCRIPTION
## 🛠️ Fix: Tailwind CSS Variables Error

This PR fixes the `border-border` class error that was causing Vite to fail during development.

### 🐛 Problem
The error was occurring because the `tailwind.config.js` was missing the standard shadcn/ui color definitions that map to the CSS variables defined in `index.css`.

### ✅ Solution
- Added all required shadcn/ui color mappings (`border`, `input`, `ring`, `background`, etc.)
- Preserved your beautiful divine color palette
- Added missing `borderRadius` and `accordion` animation definitions
- Ensured proper mapping from CSS variables to Tailwind utility classes

### 🎨 Changes Made
- ✅ Fixed `border-border` class error
- ✅ Added standard shadcn/ui color system
- ✅ Preserved divine/olympus/zeus color themes
- ✅ Added missing container and borderRadius configs
- ✅ Added accordion animations for UI components

### 🧪 Testing
After merging this PR, your `npm run dev` should work without the CSS variable errors.

### 📁 Files Modified
- `frontend/tailwind.config.js` - Added missing color definitions while preserving divine theme