### PR TITLE
Fix: Correct provider hierarchy to resolve useWebSocket context error

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,8 +13,8 @@ import { ConfigProvider } from '@/contexts/ConfigContext'
 function App() {
   return (
     <ThemeProvider defaultTheme="dark" storageKey="olympian-theme">
-      <ConfigProvider>
-        <WebSocketProvider>
+      <WebSocketProvider>
+        <ConfigProvider>
           <Layout>
             <Routes>
               <Route path="/" element={<DivineDashboard />} />
@@ -27,8 +27,8 @@ function App() {
             </Routes>
           </Layout>
           <Toaster />
-        </WebSocketProvider>
-      </ConfigProvider>
+        </ConfigProvider>
+      </WebSocketProvider>
     </ThemeProvider>
   )
 }


### PR DESCRIPTION
## 🛠️ Fix: Provider Hierarchy Error

This PR fixes the `useWebSocket must be used within a WebSocketProvider` error that was preventing the application from loading.

### 🐛 Problem
The `ConfigProvider` was trying to use the `useWebSocket()` hook, but it was wrapped **outside** of the `WebSocketProvider`. This created an invalid provider hierarchy where `ConfigProvider` couldn't access the WebSocket context.

**Previous (incorrect) hierarchy:**
```
ThemeProvider
  ConfigProvider (❌ tries to use useWebSocket)
    WebSocketProvider (✅ provides useWebSocket)
```

### ✅ Solution
Reordered the providers so that `WebSocketProvider` wraps `ConfigProvider`, allowing proper access to the WebSocket context.

**Fixed hierarchy:**
```
ThemeProvider
  WebSocketProvider (✅ provides useWebSocket)
    ConfigProvider (✅ can now use useWebSocket)
```

### 🔧 Changes Made
- Moved `WebSocketProvider` to wrap `ConfigProvider` in `App.tsx`
- Fixed the context dependency chain
- Eliminated the React context error

### 🧪 Testing
After merging this PR, the application should load without the WebSocket context errors, and the divine connection to Olympus should be established properly.

### 📁 Files Modified
- `frontend/src/App.tsx` - Fixed provider hierarchy order