### PR TITLE
Fix: Add proper WebSocket typing to resolve 403 Forbidden errors

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -4,7 +4,7 @@ Divine intelligence meets mortal ambition
 """
 import os
 from contextlib import asynccontextmanager
-from fastapi import FastAPI
+from fastapi import FastAPI, WebSocket
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from loguru import logger
@@ -124,13 +124,13 @@ app.include_router(webhooks.router, prefix="/api/webhooks", tags=["webhooks"])
 
 # Add WebSocket endpoints - both with and without client_id
 @app.websocket("/ws/{client_id}")
-async def websocket_route_with_id(websocket, client_id: str):
+async def websocket_route_with_id(websocket: WebSocket, client_id: str):
     """WebSocket endpoint for real-time communication with specific client ID"""
     await websocket_endpoint(websocket, client_id)
 
 
 @app.websocket("/ws")
-async def websocket_route_auto_id(websocket):
+async def websocket_route_auto_id(websocket: WebSocket):
     """WebSocket endpoint for real-time communication with auto-generated client ID"""
     await websocket_endpoint(websocket, None)
 


### PR DESCRIPTION
## 🛠️ Fix: WebSocket 403 Forbidden Error - Missing Type Annotation

This PR fixes the final remaining issue preventing WebSocket connections.

### 🐛 Issue Fixed

**WebSocket 403 Forbidden Errors**
- WebSocket connections were being rejected due to missing type annotations
- FastAPI requires proper `WebSocket` typing for WebSocket endpoints

### ✅ Changes Made

#### `backend/main.py`
- ✅ Added `WebSocket` import from FastAPI
- ✅ Fixed `websocket` parameter typing in both endpoints:
  - `websocket: WebSocket` instead of `websocket`
- ✅ Proper FastAPI WebSocket endpoint registration

### 🔧 Technical Details

The issue was in the WebSocket endpoint function signatures:

**Before (causing 403):**
```python
@app.websocket("/ws")
async def websocket_route_auto_id(websocket):  # Missing type annotation
```

**After (working):**
```python
@app.websocket("/ws")
async def websocket_route_auto_id(websocket: WebSocket):  # Proper typing
```

### 🧪 Expected Results

After merging:
- ✅ WebSocket connections should establish successfully
- ✅ No more 403 Forbidden errors in WebSocket logs  
- ✅ Real-time communication between frontend and backend
- ✅ Complete divine connection to Olympus! ⚡️🏛️

### 📁 Files Modified
- `backend/main.py` - Fixed WebSocket endpoint typing