### PR TITLE
Fix Switch component prop TypeScript error

### DIFF
--- a/frontend/src/components/SacredOllamaEndpoints.tsx
+++ b/frontend/src/components/SacredOllamaEndpoints.tsx
@@ -626,7 +626,6 @@ const SacredOllamaEndpoints: React.FC<SacredOllamaEndpointsProps> = ({ className
                           onCheckedChange={(checked) => 
                             updateEndpoint(endpoint.url, { enabled: checked })
                           }
-                          size="sm"
                         />
                         
                         <Button


### PR DESCRIPTION
## Fix Last TypeScript Build Error

This PR fixes the final remaining TypeScript error that was preventing the frontend from building.

### Problem
The `Switch` component from the UI library doesn't support a `size` prop, but it was being used in `SacredOllamaEndpoints.tsx` at line 629.

### Solution
Removed the unsupported `size="sm"` prop from the Switch component.

### Testing
```bash
docker system prune -a
make docker-up
```

The frontend should now build successfully!